### PR TITLE
Fix operand matrix setup for current ScaleSim API

### DIFF
--- a/krittika/simulator.py
+++ b/krittika/simulator.py
@@ -5,6 +5,7 @@ import logging
 from krittika.workload_manager import WorkloadManager
 from scalesim.scale_config import scale_config
 from scalesim.compute.operand_matrix import operand_matrix
+from scalesim.layout_utils import layouts
 from krittika.config.krittika_config import KrittikaConfig
 from krittika.partition_manager import PartitionManager
 from krittika.single_layer_sim import SingleLayerSim
@@ -99,6 +100,7 @@ class Simulator:
         conf_list[10] = self.config_obj.get_bandwidth_use_mode()
         conf_list.append(self.config_obj.get_interface_bandwidths()[0])
         single_arr_config.update_from_list(conf_list=conf_list)
+        default_layout = layouts()
 
         for layer_id in range(num_layers):
             if self.verbose:
@@ -108,6 +110,7 @@ class Simulator:
             if (layer_params[0] in ['conv', 'gemm']):
                 this_layer_op_mat_obj.set_params(config_obj=single_arr_config,
                                              topoutil_obj=self.workload_obj,
+                                             layoututil_obj=default_layout,
                                              layer_id=layer_id)
                 this_layer_op_mat_obj.create_operand_matrices()
 

--- a/krittika/workload_manager.py
+++ b/krittika/workload_manager.py
@@ -159,6 +159,16 @@ class WorkloadManager:
         return layer_params[8:10]
 
     #
+    def get_layer_sparsity_ratio(self, layer_id=0):
+        if not (self.topo_valid or self.num_layers - 1 < layer_id):
+            print("ERROR: topologies.get_layer_sparsity_ratio: Invalid layer id")
+
+        layer_params = self.topo_list[layer_id]
+        assert layer_params[0] in ['conv', 'gemm'], 'It should be a conv/gemm layer'
+
+        return 1, 1
+
+    #
     def get_layer_window_size(self, layer_id=0):
         if not (self.topo_valid or self.num_layers - 1 < layer_id):
             print("ERROR: topologies.get_layer_num_filter: Invalid layer id")


### PR DESCRIPTION
## Why

Krittika was not fully compatible with the current scalesim operand matrix setup flow. The simulator did not provide the layout utility expected by `operand_matrix.set_params`, and `WorkloadManager` did not expose the sparsity-ratio method expected by the updated operand matrix code.

## What this fixes

This fixes simulator failures during operand matrix creation by passing a default layout utility into `operand_matrix.set_params` and adding `get_layer_sparsity_ratio` to `WorkloadManager`.

---

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/89424bb6-1888-4ba3-aaa6-f99417b19c5c" />
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/15497b63-ef02-4a53-95d7-3aef114742ca" />
