### PR TITLE
Fix trace directory creation on Windows

### DIFF
--- a/krittika/single_layer_sim.py
+++ b/krittika/single_layer_sim.py
@@ -1,5 +1,5 @@
 import math
-import os.path
+import os
 
 from scalesim.compute.operand_matrix import operand_matrix
 from scalesim.memory.double_buffered_scratchpad_mem import double_buffered_scratchpad
@@ -365,12 +365,4 @@ class SingleLayerSim:
 
     @staticmethod
     def check_and_build(dirname):
-        if not os.path.isdir(dirname):
-            cmd = 'mkdir ' + dirname
-            os.system(cmd)
-
-
-
-
-
-
+        os.makedirs(dirname, exist_ok=True)


### PR DESCRIPTION
## Why

Krittika creates trace output directories using a shell `mkdir` command built from the output path. On Windows, errors can occur if the file path contains spaces, resulting in the message `The syntax of the command is incorrect`, as shown in the image below.

## What this fixes
This allows the creation of trace directories correctly across platforms, including paths that contain spaces.

The old existence check is removed because `os.makedirs(..., exist_ok=True)` safely handles existing directories and creates missing ones without needing a separate `os.path.isdir` check.

---
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/4f938e39-c765-4f40-88ae-70461b848c7d" />
