### PR TITLE
Fix CLI boolean parsing for savetrace and verbose

### DIFF
--- a/krittika/krittika-sim.py
+++ b/krittika/krittika-sim.py
@@ -2,6 +2,11 @@ import argparse
 
 from krittika.simulator import Simulator
 
+def str_to_bool(value):
+    if value.lower() not in ('true', 'false'):
+        raise argparse.ArgumentTypeError('Expected True or False.')
+    return value.lower() == 'true'
+
 if __name__ == '__main__':
     '''
         Input parameters:
@@ -35,12 +40,12 @@ if __name__ == '__main__':
                         help='Path to the log dump directory'
                         )
 
-    parser.add_argument('--verbose', metavar='Verbosity', type=bool,
+    parser.add_argument('--verbose', metavar='Verbosity', type=str_to_bool,
                         default=True,
                         help='Flag to change the verbosity of the run'
                         )
 
-    parser.add_argument('--savetrace', metavar='Save traces', type=bool,
+    parser.add_argument('--savetrace', metavar='Save traces', type=str_to_bool,
                         default=False,
                         help='Flag to indicate if the traces should be saved'
                         )

--- a/krittika/simulator.py
+++ b/krittika/simulator.py
@@ -120,10 +120,12 @@ class Simulator:
                                       verbosity=self.verbose)
                 this_layer_sim.run()
                 self.single_layer_objects_list += [this_layer_sim]
+                
+                if self.trace_gen_flag:
+                    if self.verbose:
+                        print('SAVING TRACES')
+                    this_layer_sim.save_traces()
 
-                if self.verbose:
-                    print('SAVING TRACES')
-                this_layer_sim.save_traces()
                 this_layer_sim.gather_report_items_across_cores()
             elif (layer_params[0] in ['activation']):
                 op_matrix = self.single_layer_objects_list[layer_id-1].get_ofmap_operand_matrix()
@@ -147,6 +149,7 @@ class Simulator:
         self.generate_all_reports()
 
     def generate_all_reports(self):
+        os.makedirs(os.path.join(self.top_path, 'traces'), exist_ok=True)
         self.create_cycles_report_structures()
         self.create_bandwidth_report_structures()
         self.create_detailed_report_structures()


### PR DESCRIPTION
## Issues

The `--savetrace` CLI option was incorrectly handled because `argparse` used `type=bool`, passing `--savetrace False` was still parsed as `True`. This is because CLI input arg of "False" gets parsed as `bool("False") == True` which is still True.

Similarly, `verbose` had the same issue.

Other/cascading issues:

- `verbose` always evaluates to true, printing `SAVING TRACES`. Also skipping `trace_gen_flag` checks.
- `trace_gen_flag` is not being checked before calling `save_traces`, causing traces to be saved unconditionally.
- `generate_all_reports` may not have `traces` folder created, causing `FileNotFoundError` when later opening it in the following methods. 

## Fixes

- Added helper function `str_to_bool` to parse arguments correctly.
- Patched `SAVING TRACES` message so both `verbose` and `trace_gen_flag` need to be enabled to see this message. (Previously did not check for `trace_gen_flag`.
- Patched the top-level `traces` folder exists before summary reports are written.

## Other Notes
The `krittika/krittika-sim.py` comments say `--savetrace: ... (Default: True)`, but the actual argument defaults to `False`. This PR keeps the runtime default as `False`.